### PR TITLE
fix: use git commit instead of git branch for segment dependency

### DIFF
--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -1,11 +1,13 @@
 Pod::Spec.new do |s|
     s.name = "AnalyticsSwiftCIO"
-    s.version = "1.5.5"
+    s.version = "1.5.5-cio.1"
     s.license = { :type => 'MIT', :file => './LICENSE' }
     s.summary = "Customer.io Data Pipelines analytics client for Swift app (iOS/tvOS/watchOS/macOS/Linux)."
     s.homepage = "https://github.com/customerio/cdp-analytics-swift"
     s.authors = "Customer.io"
-    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'main' }
+
+    # The version is a git commit hash. Make sure the commit is the same as what SPM customers are using.
+    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :commit => 'b2f8f5b68dd0d8796b4bacdec39aacb5b6387a41' }
 
     s.ios.deployment_target = "13.0"
     s.requires_arc = true


### PR DESCRIPTION
Part of: https://linear.app/customerio/issue/MBL-167/segment-dependency-currently-pointing-to-main-branch

In the iOS SDK today, with the Segment CDP SDK, we are currently specifying the version of the segment SDK as "main branch". Using a git branch as the version of a dependency poses risks, potentially leading to difficulties for customers during SDK updates and app compilation, increasing the chance of crashes or compilation issues.

This change uses a hard-coded git commit. The git commit used is the latest commit on the "main" branch.

There are pros and cons to using a git commit as the version, as specified in the ticket description. We can change to a different version such as a git tag in the future.

Note: In order for this change to be used in the iOS SDK, we need to push version 1.5.6 to the CocoaPods server and then update the iOS SDK cocoapods version to >= 1.5.6

commit-id:b1e7e3d3