### PR TITLE
fix: segment compatibility

### DIFF
--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -7,15 +7,14 @@ Pod::Spec.new do |s|
     s.authors = "Customer.io"
 
     # Make sure the tag is the same as what SPM customers are using.
-    # TODO: update it to version, once we decide to release it.
-    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'shahroz/different-target' }
+    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :tag => '1.5.11+cio.1' }
 
     s.ios.deployment_target = "13.0"
     s.requires_arc = true
 
     s.swift_version = '5.3'
     s.cocoapods_version = '>= 1.11.0'
-    s.module_name = "CDPAnalyticsSwift"
+    s.module_name = "CioAnalytics"
 
     s.source_files = "Sources/**/*.swift"
     s.resource_bundles = {

--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -7,7 +7,8 @@ Pod::Spec.new do |s|
     s.authors = "Customer.io"
 
     # Make sure the tag is the same as what SPM customers are using.
-    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :tag => '1.5.11+cio.1' }
+    # update branch to version
+    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'shahroz/different-target' }
 
     s.ios.deployment_target = "13.0"
     s.requires_arc = true

--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
     s.name = "AnalyticsSwiftCIO"
-    s.version = "1.5.11+cio.1"
+    s.version = "1.5.12+cio.1"
     s.license = { :type => 'MIT', :file => './LICENSE' }
     s.summary = "Customer.io Data Pipelines analytics client for Swift app (iOS/tvOS/watchOS/macOS/Linux)."
     s.homepage = "https://github.com/customerio/cdp-analytics-swift"
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
 
     # Make sure the tag is the same as what SPM customers are using.
     # update branch to version
-    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'shahroz/different-target' }
+    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :tag => '1.5.12+cio.1' }
 
     s.ios.deployment_target = "13.0"
     s.requires_arc = true

--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -7,14 +7,14 @@ Pod::Spec.new do |s|
     s.authors = "Customer.io"
 
     # Make sure the tag is the same as what SPM customers are using.
-    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :tag => '1.5.9+cio.1' }
+    s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'shahroz/different-target' }
 
     s.ios.deployment_target = "13.0"
     s.requires_arc = true
 
     s.swift_version = '5.3'
     s.cocoapods_version = '>= 1.11.0'
-    s.module_name = "Segment"
+    s.module_name = "CDPAnalyticsSwift"
 
     s.source_files = "Sources/**/*.swift"
     s.resource_bundles = {

--- a/AnalyticsSwiftCIO.podspec
+++ b/AnalyticsSwiftCIO.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
     s.authors = "Customer.io"
 
     # Make sure the tag is the same as what SPM customers are using.
+    # TODO: update it to version, once we decide to release it.
     s.source = { :git => 'https://github.com/customerio/cdp-analytics-swift.git', :branch => 'shahroz/different-target' }
 
     s.ios.deployment_target = "13.0"

--- a/Examples/apps/ObjCExample/ObjCExample/TestDestination.swift
+++ b/Examples/apps/ObjCExample/ObjCExample/TestDestination.swift
@@ -8,7 +8,7 @@
 import Foundation
 import Segment
 
-@objc(SEGTestDestination)
+@objc(CIOTestDestination)
 public class ObjCTestDestination: NSObject, ObjCPlugin, ObjCPluginShim {
     public func instance() -> EventPlugin { return TestDestination() }
 }

--- a/Examples/apps/SegmentUIKitExample/SegmentUIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/apps/SegmentUIKitExample/SegmentUIKitExample.xcodeproj/project.pbxproj
@@ -7,7 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		301A7CF42BB79195007AF8A5 /* CDPAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */; };
+		30678B7F2BE982DC000C3E2D /* CioAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 30678B7E2BE982DC000C3E2D /* CioAnalytics */; };
 		46022785261F860100A9E913 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022784261F860100A9E913 /* AppDelegate.swift */; };
 		46022787261F860100A9E913 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022786261F860100A9E913 /* SceneDelegate.swift */; };
 		46022789261F860100A9E913 /* Tab1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022788261F860100A9E913 /* Tab1ViewController.swift */; };
@@ -48,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				301A7CF42BB79195007AF8A5 /* CDPAnalyticsSwift in Frameworks */,
+				30678B7F2BE982DC000C3E2D /* CioAnalytics in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,7 +138,7 @@
 			);
 			name = SegmentUIKitExample;
 			packageProductDependencies = (
-				301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */,
+				30678B7E2BE982DC000C3E2D /* CioAnalytics */,
 			);
 			productName = SegmentUIKitExample;
 			productReference = 46022781261F860100A9E913 /* SegmentUIKitExample.app */;
@@ -439,9 +439,9 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
-		301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */ = {
+		30678B7E2BE982DC000C3E2D /* CioAnalytics */ = {
 			isa = XCSwiftPackageProductDependency;
-			productName = CDPAnalyticsSwift;
+			productName = CioAnalytics;
 		};
 		460227A0261F887C00A9E913 /* Segment */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Examples/apps/SegmentUIKitExample/SegmentUIKitExample.xcodeproj/project.pbxproj
+++ b/Examples/apps/SegmentUIKitExample/SegmentUIKitExample.xcodeproj/project.pbxproj
@@ -3,10 +3,11 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		301A7CF42BB79195007AF8A5 /* CDPAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = 301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */; };
 		46022785261F860100A9E913 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022784261F860100A9E913 /* AppDelegate.swift */; };
 		46022787261F860100A9E913 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022786261F860100A9E913 /* SceneDelegate.swift */; };
 		46022789261F860100A9E913 /* Tab1ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46022788261F860100A9E913 /* Tab1ViewController.swift */; };
@@ -19,7 +20,6 @@
 		46E3834E26582D9E00BA2502 /* IDFACollection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E3834A26582D9E00BA2502 /* IDFACollection.swift */; };
 		46E3835326582DA400BA2502 /* CustomScreenTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E3835126582DA400BA2502 /* CustomScreenTracking.swift */; };
 		46E3835426582DA400BA2502 /* MultiInstance.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E3835226582DA400BA2502 /* MultiInstance.swift */; };
-		46E383572658307800BA2502 /* Segment in Frameworks */ = {isa = PBXBuildFile; productRef = 46E383562658307800BA2502 /* Segment */; };
 		46E73DA326F531320021042C /* NotificationTracking.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46E73DA226F531320021042C /* NotificationTracking.swift */; };
 /* End PBXBuildFile section */
 
@@ -48,7 +48,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				46E383572658307800BA2502 /* Segment in Frameworks */,
+				301A7CF42BB79195007AF8A5 /* CDPAnalyticsSwift in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -138,7 +138,7 @@
 			);
 			name = SegmentUIKitExample;
 			packageProductDependencies = (
-				46E383562658307800BA2502 /* Segment */,
+				301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */,
 			);
 			productName = SegmentUIKitExample;
 			productReference = 46022781261F860100A9E913 /* SegmentUIKitExample.app */;
@@ -439,13 +439,13 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		301A7CF32BB79195007AF8A5 /* CDPAnalyticsSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = CDPAnalyticsSwift;
+		};
 		460227A0261F887C00A9E913 /* Segment */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 4602279B261F884600A9E913 /* XCRemoteSwiftPackageReference "analytics-swift" */;
-			productName = Segment;
-		};
-		46E383562658307800BA2502 /* Segment */ = {
-			isa = XCSwiftPackageProductDependency;
 			productName = Segment;
 		};
 /* End XCSwiftPackageProductDependency section */

--- a/Examples/apps/SegmentUIKitExample/SegmentUIKitExample/AppDelegate.swift
+++ b/Examples/apps/SegmentUIKitExample/SegmentUIKitExample/AppDelegate.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import CDPAnalyticsSwift
+import CioAnalytics
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Examples/apps/SegmentUIKitExample/SegmentUIKitExample/AppDelegate.swift
+++ b/Examples/apps/SegmentUIKitExample/SegmentUIKitExample/AppDelegate.swift
@@ -6,7 +6,7 @@
 //
 
 import UIKit
-import Segment
+import CDPAnalyticsSwift
 
 @main
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Examples/other_plugins/CellularCarrier.swift
+++ b/Examples/other_plugins/CellularCarrier.swift
@@ -35,7 +35,7 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
 
 import Foundation
-import CDPAnalyticsSwift
+import CioAnalytics
 import CoreTelephony
 
 /**

--- a/Examples/other_plugins/CellularCarrier.swift
+++ b/Examples/other_plugins/CellularCarrier.swift
@@ -35,7 +35,7 @@
 #if os(iOS) && !targetEnvironment(macCatalyst)
 
 import Foundation
-import Segment
+import CDPAnalyticsSwift
 import CoreTelephony
 
 /**

--- a/Examples/other_plugins/ConsentTracking.swift
+++ b/Examples/other_plugins/ConsentTracking.swift
@@ -33,7 +33,7 @@
 // SOFTWARE.
 
 import Foundation
-import CDPAnalyticsSwift
+import CioAnalytics
 import UIKit
 
 /**

--- a/Examples/other_plugins/ConsentTracking.swift
+++ b/Examples/other_plugins/ConsentTracking.swift
@@ -33,7 +33,7 @@
 // SOFTWARE.
 
 import Foundation
-import Segment
+import CDPAnalyticsSwift
 import UIKit
 
 /**

--- a/Examples/other_plugins/IDFACollection.swift
+++ b/Examples/other_plugins/IDFACollection.swift
@@ -34,7 +34,7 @@
 
 import Foundation
 import UIKit
-import CDPAnalyticsSwift
+import CioAnalytics
 import AdSupport
 import AppTrackingTransparency
 

--- a/Examples/other_plugins/IDFACollection.swift
+++ b/Examples/other_plugins/IDFACollection.swift
@@ -34,7 +34,7 @@
 
 import Foundation
 import UIKit
-import Segment
+import CDPAnalyticsSwift
 import AdSupport
 import AppTrackingTransparency
 

--- a/Examples/other_plugins/NotificationTracking.swift
+++ b/Examples/other_plugins/NotificationTracking.swift
@@ -36,7 +36,7 @@
 #if !os(Linux) && !os(macOS)
 
 import Foundation
-import CDPAnalyticsSwift
+import CioAnalytics
 
 class NotificationTracking: Plugin {
     var type: PluginType = .utility

--- a/Examples/other_plugins/NotificationTracking.swift
+++ b/Examples/other_plugins/NotificationTracking.swift
@@ -36,7 +36,7 @@
 #if !os(Linux) && !os(macOS)
 
 import Foundation
-import Segment
+import CDPAnalyticsSwift
 
 class NotificationTracking: Plugin {
     var type: PluginType = .utility

--- a/Examples/other_plugins/UIKitScreenTracking.swift
+++ b/Examples/other_plugins/UIKitScreenTracking.swift
@@ -33,7 +33,7 @@
 // SOFTWARE.
 
 import Foundation
-import CDPAnalyticsSwift
+import CioAnalytics
 import UIKit
 
 /**

--- a/Examples/other_plugins/UIKitScreenTracking.swift
+++ b/Examples/other_plugins/UIKitScreenTracking.swift
@@ -33,7 +33,7 @@
 // SOFTWARE.
 
 import Foundation
-import Segment
+import CDPAnalyticsSwift
 import UIKit
 
 /**

--- a/Examples/tasks/CustomScreenTracking.swift
+++ b/Examples/tasks/CustomScreenTracking.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 import UIKit
-import CDPAnalyticsSwift
+import CioAnalytics
 
 class QueryAlertController: UIAlertController {
     // we already conform to UIKitScreenTrackable so override

--- a/Examples/tasks/CustomScreenTracking.swift
+++ b/Examples/tasks/CustomScreenTracking.swift
@@ -31,7 +31,7 @@
 
 import Foundation
 import UIKit
-import Segment
+import CDPAnalyticsSwift
 
 class QueryAlertController: UIAlertController {
     // we already conform to UIKitScreenTrackable so override

--- a/Examples/tasks/MultiInstance.swift
+++ b/Examples/tasks/MultiInstance.swift
@@ -30,7 +30,7 @@
 // SOFTWARE.
 
 import Foundation
-import CDPAnalyticsSwift
+import CioAnalytics
 
 /**
  An example of implementing multiple Analytics instances in a single application.

--- a/Examples/tasks/MultiInstance.swift
+++ b/Examples/tasks/MultiInstance.swift
@@ -30,7 +30,7 @@
 // SOFTWARE.
 
 import Foundation
-import Segment
+import CDPAnalyticsSwift
 
 /**
  An example of implementing multiple Analytics instances in a single application.

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "CDPAnalyticsSwift",
+    name: "CioAnalytics",
     platforms: [
         .macOS("10.15"),
         .iOS("13.0"),
@@ -15,8 +15,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "CDPAnalyticsSwift",
-            targets: ["CDPAnalyticsSwift"]),
+            name: "CioAnalytics",
+            targets: ["CioAnalytics"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -28,14 +28,14 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "CDPAnalyticsSwift",
+            name: "CioAnalytics",
             dependencies: [
                 .product(name: "Sovran", package: "sovran-swift"),
                 .product(name: "JSONSafeEncoding", package: "jsonsafeencoding-swift")
             ],
             resources: [.process("Segment/Resources")]),
         .testTarget(
-            name: "CDPAnalyticsSwift-Tests",
-            dependencies: ["CDPAnalyticsSwift"]),
+            name: "CioAnalytics-Tests",
+            dependencies: ["CioAnalytics"]),
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@
 import PackageDescription
 
 let package = Package(
-    name: "Segment",
+    name: "CDPAnalyticsSwift",
     platforms: [
         .macOS("10.15"),
         .iOS("13.0"),
@@ -15,8 +15,8 @@ let package = Package(
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
-            name: "Segment",
-            targets: ["Segment"]),
+            name: "CDPAnalyticsSwift",
+            targets: ["CDPAnalyticsSwift"]),
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
@@ -28,14 +28,14 @@ let package = Package(
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.
         // Targets can depend on other targets in this package, and on products in packages this package depends on.
         .target(
-            name: "Segment",
+            name: "CDPAnalyticsSwift",
             dependencies: [
                 .product(name: "Sovran", package: "sovran-swift"),
                 .product(name: "JSONSafeEncoder", package: "jsonsafeencoder-swift")
             ],
-            resources: [.process("Resources")]),
+            resources: [.process("Segment/Resources")]),
         .testTarget(
-            name: "Segment-Tests",
-            dependencies: ["Segment"]),
+            name: "CDPAnalyticsSwift-Tests",
+            dependencies: ["CDPAnalyticsSwift"]),
     ]
 )

--- a/Sources/Segment/ObjC/ObjCAnalytics.swift
+++ b/Sources/Segment/ObjC/ObjCAnalytics.swift
@@ -12,7 +12,7 @@ import JSONSafeEncoding
 
 // MARK: - ObjC Compatibility
 
-@objc(SEGAnalytics)
+@objc(CIOAnalytics)
 public class ObjCAnalytics: NSObject {
     /// The underlying Analytics object we're working with
     public let analytics: Analytics

--- a/Sources/Segment/ObjC/ObjCConfiguration.swift
+++ b/Sources/Segment/ObjC/ObjCConfiguration.swift
@@ -10,7 +10,7 @@
 import Foundation
 import JSONSafeEncoding
 
-@objc(SEGConfiguration)
+@objc(CIOConfiguration)
 public class ObjCConfiguration: NSObject {
     internal var configuration: Configuration
     

--- a/Sources/Segment/ObjC/ObjCEvents.swift
+++ b/Sources/Segment/ObjC/ObjCEvents.swift
@@ -14,7 +14,7 @@ internal protocol ObjCEvent {
     var _event: EventType { get set }
 }
 
-@objc(SEGDestinationMetadata)
+@objc(CIODestinationMetadata)
 public class ObjCDestinationMetadata: NSObject {
     internal var _metadata: DestinationMetadata
     
@@ -43,7 +43,7 @@ public class ObjCDestinationMetadata: NSObject {
     }
 }
 
-@objc(SEGRawEvent)
+@objc(CIORawEvent)
 public protocol ObjCRawEvent: NSObjectProtocol {
     var type: String? { get }
     var messageId: String? { get }
@@ -80,7 +80,7 @@ internal func objcEventFromEvent<T: RawEvent>(_ event: T?) -> ObjCRawEvent? {
     }
 }
 
-@objc(SEGTrackEvent)
+@objc(CIOTrackEvent)
 public class ObjCTrackEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: TrackEvent
     
@@ -139,7 +139,7 @@ public class ObjCTrackEvent: NSObject, ObjCEvent, ObjCRawEvent {
     }
 }
 
-@objc(SEGIdentifyEvent)
+@objc(CIOIdentifyEvent)
 public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: IdentifyEvent
     
@@ -192,7 +192,7 @@ public class ObjCIdentifyEvent: NSObject, ObjCEvent, ObjCRawEvent {
     }
 }
 
-@objc(SEGScreenEvent)
+@objc(CIOScreenEvent)
 public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: ScreenEvent
     
@@ -257,7 +257,7 @@ public class ObjCScreenEvent: NSObject, ObjCEvent, ObjCRawEvent {
     }
 }
 
-@objc(SEGGroupEvent)
+@objc(CIOGroupEvent)
 public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: GroupEvent
     
@@ -316,7 +316,7 @@ public class ObjCGroupEvent: NSObject, ObjCEvent, ObjCRawEvent {
     }
 }
 
-@objc(SEGAliasEvent)
+@objc(CIOAliasEvent)
 public class ObjCAliasEvent: NSObject, ObjCEvent, ObjCRawEvent {
     internal var _event: AliasEvent
     

--- a/Sources/Segment/ObjC/ObjCPlugin.swift
+++ b/Sources/Segment/ObjC/ObjCPlugin.swift
@@ -10,7 +10,7 @@
 
 import Foundation
 
-@objc(SEGPlugin)
+@objc(CIOPlugin)
 public protocol ObjCPlugin {}
 
 public protocol ObjCPluginShim {
@@ -20,14 +20,14 @@ public protocol ObjCPluginShim {
 // NOTE: Destination plugins need something similar to the following to work/
 /*
 
-@objc(SEGMixpanelDestination)
+@objc(CIOMixpanelDestination)
 public class ObjCSegmentMixpanel: NSObject, ObjCPlugin, ObjCPluginShim {
     public func instance() -> EventPlugin { return MixpanelDestination() }
 }
 
 */
 
-@objc(SEGEventPlugin)
+@objc(CIOEventPlugin)
 public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
     public var type: PluginType = .enrichment
     public weak var analytics: Analytics? = nil
@@ -48,7 +48,7 @@ public class ObjCEventPlugin: NSObject, EventPlugin, ObjCPlugin {
     }
 }
 
-@objc(SEGBlockPlugin)
+@objc(CIOBlockPlugin)
 public class ObjCBlockPlugin: ObjCEventPlugin {
     let block: (ObjCRawEvent?) -> ObjCRawEvent?
     

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -190,7 +190,7 @@ extension SegmentDestination {
                             
                             // we don't want to retry events in a given batch when a 400
                             // response for malformed JSON is returned
-                        case .failure(Segment.HTTPClientErrors.statusCode(code: 400)):
+                        case .failure(CDPAnalyticsSwift.HTTPClientErrors.statusCode(code: 400)):
                             storage.remove(data: [url])
                             cleanupUploads()
                         default:

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -190,7 +190,7 @@ extension SegmentDestination {
                             
                             // we don't want to retry events in a given batch when a 400
                             // response for malformed JSON is returned
-                        case .failure(CDPAnalyticsSwift.HTTPClientErrors.statusCode(code: 400)):
+                        case .failure(CioAnalytics.HTTPClientErrors.statusCode(code: 400)):
                             storage.remove(data: [url])
                             cleanupUploads()
                         default:
@@ -261,7 +261,7 @@ extension SegmentDestination {
                     
                     // we don't want to retry events in a given batch when a 400
                     // response for malformed JSON is returned
-                case .failure(CDPAnalyticsSwift.HTTPClientErrors.statusCode(code: 400)):
+                case .failure(CioAnalytics.HTTPClientErrors.statusCode(code: 400)):
                     storage.remove(data: removable)
                     cleanupUploads()
                 default:

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -16,9 +16,9 @@ import Sovran
 import FoundationNetworking
 #endif
 
-public class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion {
+open class SegmentDestination: DestinationPlugin, Subscriber, FlushCompletion {
     internal enum Constants: String {
-        case integrationName = "Segment.io"
+        case integrationName = "Customer.io Data Pipelines"
         case apiHost = "apiHost"
         case apiKey = "apiKey"
     }

--- a/Sources/Segment/Plugins/SegmentDestination.swift
+++ b/Sources/Segment/Plugins/SegmentDestination.swift
@@ -177,7 +177,7 @@ extension SegmentDestination {
                     
                     // we don't want to retry events in a given batch when a 400
                     // response for malformed JSON is returned
-                case .failure(Segment.HTTPClientErrors.statusCode(code: 400)):
+                case .failure(CDPAnalyticsSwift.HTTPClientErrors.statusCode(code: 400)):
                     storage.remove(data: [url])
                     cleanupUploads()
                 default:
@@ -241,7 +241,7 @@ extension SegmentDestination {
                     
                     // we don't want to retry events in a given batch when a 400
                     // response for malformed JSON is returned
-                case .failure(Segment.HTTPClientErrors.statusCode(code: 400)):
+                case .failure(CDPAnalyticsSwift.HTTPClientErrors.statusCode(code: 400)):
                     storage.remove(data: removable)
                     cleanupUploads()
                 default:

--- a/Sources/Segment/Utilities/Storage/Storage.swift
+++ b/Sources/Segment/Utilities/Storage/Storage.swift
@@ -24,7 +24,7 @@ internal class Storage: Subscriber {
         self.storageMode = storageMode
         self.userDefaults = UserDefaults(suiteName: "com.segment.storage.\(writeKey)")!
         
-        var storageURL = CDPAnalyticsSwift.eventStorageDirectory(writeKey: writeKey)
+        var storageURL = CioAnalytics.eventStorageDirectory(writeKey: writeKey)
         let asyncAppend = (operatingMode == .asynchronous)
         switch storageMode {
         case .diskAtURL(let url):

--- a/Sources/Segment/Utilities/Storage/Storage.swift
+++ b/Sources/Segment/Utilities/Storage/Storage.swift
@@ -24,7 +24,7 @@ internal class Storage: Subscriber {
         self.storageMode = storageMode
         self.userDefaults = UserDefaults(suiteName: "com.segment.storage.\(writeKey)")!
         
-        var storageURL = Segment.eventStorageDirectory(writeKey: writeKey)
+        var storageURL = CDPAnalyticsSwift.eventStorageDirectory(writeKey: writeKey)
         let asyncAppend = (operatingMode == .asynchronous)
         switch storageMode {
         case .diskAtURL(let url):

--- a/Tests/Segment-Tests/Support/TestUtilities.swift
+++ b/Tests/Segment-Tests/Support/TestUtilities.swift
@@ -68,7 +68,7 @@ class ZiggyPlugin: EventPlugin {
 
 #if !os(Linux)
 
-@objc(SEGMyDestination)
+@objc(CIOMyDestination)
 public class ObjCMyDestination: NSObject, ObjCPlugin, ObjCPluginShim {
     public func instance() -> EventPlugin { return MyDestination() }
 }


### PR DESCRIPTION
Problem:
Our fork and Segment SDK can't be added at the same time via SPM.

Solution:
Update module name from `Segment` to `CioAnalytics`.

Changes:
- Package.json for updated module name
- Podspec for updated module name
- External Module reference of `Segment` 
- Sample Apps
- Objc symbols to avoid linker issues because of same objc names