### PR TITLE
Move off of deprecated APIs for package dependencies

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,8 +21,8 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/segmentio/sovran-swift.git", .exact("1.1.1")),
-        .package(url: "https://github.com/segmentio/jsonsafeencoding-swift.git", .exact("2.0.0"))
+        .package(url: "https://github.com/segmentio/sovran-swift.git", exact: "1.1.1"),
+        .package(url: "https://github.com/segmentio/jsonsafeencoding-swift.git", exact: "2.0.0")
     ],
     targets: [
         // Targets are the basic building blocks of a package. A target can define a module or a test suite.


### PR DESCRIPTION
Fixes the following warnings:

```
warning: 'cdp-analytics-swift': /Package.swift:24:10: warning: 'package(url:_:)' is deprecated: use specific requirement APIs instead (e.g. use 'branch:' instead of '.branch')
        .package(url: "https://github.com/segmentio/sovran-swift.git", .exact("1.1.1")),
         ^
/Package.swift:24:73: warning: 'exact' is deprecated
        .package(url: "https://github.com/segmentio/sovran-swift.git", .exact("1.1.1")),
                                                                        ^
/Package.swift:25:10: warning: 'package(url:_:)' is deprecated: use specific requirement APIs instead (e.g. use 'branch:' instead of '.branch')
        .package(url: "https://github.com/segmentio/jsonsafeencoding-swift.git", .exact("2.0.0"))
         ^
/Package.swift:25:83: warning: 'exact' is deprecated
        .package(url: "https://github.com/segmentio/jsonsafeencoding-swift.git", .exact("2.0.0"))
                                                                                  ^
```

No functional changes.