### PR TITLE
fix: tuist users not able to install CIO iOS SDK SPM manifest issue

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -33,6 +33,7 @@ let package = Package(
                 .product(name: "Sovran", package: "sovran-swift"),
                 .product(name: "JSONSafeEncoding", package: "jsonsafeencoding-swift")
             ],
+            path: "Sources/Segment",   
             resources: [.process("Segment/Resources")]),
         .testTarget(
             name: "CioAnalytics-Tests",


### PR DESCRIPTION
Resolves: https://github.com/customerio/customerio-ios/issues/790 

# Problem 

iOS developers who want to use tools such as Tuist to generate xcode projects are currently experiencing an error when resolving the CIO iOS SDK via SPM. See the GH issue linked for Tuist config files to reproduce the issue. 

Error message: 
```
Default source path not found for target CioAnalytics in package at /private/tmp/Tuist/.build/checkouts/cdp-analytics-swift. Source path must be one of ["Sources/CioAnalytics", "Source/CioAnalytics", "src/CioAnalytics", "srcs/CioAnalytics"]
```

When reviewing the SPM manifest documentation, I do see: 
> - path: The custom path for the target. By default, the Swift Package Manager requires a target's sources to reside at predefined search paths; for example, `[PackageRoot]/Sources/[TargetName]`.

So, it makes sense that the `Package.swift` file having a target named `CioAnalytics` but the source code being located at `Sources/Segment` is causing issues. 

# Solution 

Add a `path` property to the SPM manifest file, specifying the correct directory where source code files are located. 

# Testing 

1. In CIO iOS SDK, I modified the `Package.swift` file to point to this branch: 
```swift
        .package(name: "CioAnalytics", url: "https://github.com/customerio/cdp-analytics-swift.git", .branch("levi/fix-tuist-spm"))
```
and I pushed this change to a github branch. I then went into our APN sample app and I installed the iOS SDK via the branch I pushed up. I confirmed the APN app compiled successfully. I also checked the source code that Xcode downloaded with SPM to confirm all the dependencies were downloaded from the git branches as expected. This proves that with this SPM manfiest file change, it does not break compilation for existing customers who do not use Tuist. 

2. I took the Tuist config files from the GH issue and I updated `Package.swift` to install the iOS SDK from the github branch that I created. I ran `tuist install; tuist generate` and Tuist successfully generated an xcode project without the original error. I was also able to compile the generated tuist xcode project with the CIO DataPipelines SDK installed. 

3. To be sure, I also tested cocoapods sample app pointing to this branch and verified app compiles. 